### PR TITLE
BBD-125: Do page reset before doing refined search from sayt

### DIFF
--- a/src/tags/sayt/gb-sayt.tag
+++ b/src/tags/sayt/gb-sayt.tag
@@ -70,7 +70,10 @@
       }).then(() => opts.flux.rewrite(query))
     };
     this.searchRefinement = (event) => refine(event.target, '');
-    this.searchCategory = (event) => refine(event.target, this.originalQuery);
+    this.searchCategory = (event) => {
+      opts.flux.reset();
+      refine(event.target, this.originalQuery);
+    };
     this.enhanceQuery = (query) => saytConfig.highlight ? query.replace(this.originalQuery, '<b>$&</b>') : query;
     this.enhanceCategoryQuery = (query) => {
       if (saytConfig.categoryField) {


### PR DESCRIPTION
This has the effect of clearing present refinements before doing the refined search. In particular this prevents duplicate refinements (the content of BBD-125)