### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,14 +100,14 @@
     "gb-tracker-client": "^3.2.2",
     "groupby-api": "^1.0.81",
     "js-cookie": "^2.1.3",
-    "node-uuid": "^1.4.7",
     "oget": "^1.0.6",
     "parseUri": "^1.2.3-2",
     "query-string": "^4.2.2",
     "riot": "^2.5.0",
     "sayt": "^0.1.7",
     "string.prototype.repeat": "^0.2.0",
-    "string.prototype.startswith": "^0.2.0"
+    "string.prototype.startswith": "^0.2.0",
+    "uuid": "^3.0.0"
   },
   "babel": {
     "presets": [

--- a/src/services/tracker.ts
+++ b/src/services/tracker.ts
@@ -4,7 +4,7 @@ import * as GbTracker from 'gb-tracker-client';
 import filterObject = require('filter-object');
 import { Events, FluxCapacitor } from 'groupby-api';
 import * as Cookies from 'js-cookie';
-import * as uuid from 'node-uuid';
+import * as uuid from 'uuid';
 
 export const MAX_COOKIE_AGE = 365; // days
 export const VISITOR_COOKIE_KEY = 'visitor';


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.