### PR TITLE
BBD-514: Dropdown Does Not Hide After Selecting A Collection Option

### DIFF
--- a/src/tags/select/gb-custom-select.tag.html
+++ b/src/tags/select/gb-custom-select.tag.html
@@ -1,5 +1,5 @@
 <gb-custom-select>
-  <div class="gb-select { $selectable.hover ? 'hoverable' : 'clickable' }">
+  <div class="gb-select { $selectable.hover ? 'hoverable' : 'clickable' }{ $select.activated ? ' gb-custom-select__activated' : ''}" onmouseenter="{ $select.hoverActivate }">
     <button data-is="gb-select-button" type="button" onclick="{ $select.focusElement }"></button>
     <gb-list should-render="{ $select.shouldRender }">
       <yield>
@@ -35,9 +35,9 @@
     gb-list ul:hover {
       display: block;
     }
-    .gb-select.hoverable:hover gb-list,
-    .gb-select.clickable button:focus + gb-list,
-    gb-list:hover {
+    .gb-select.hoverable.gb-custom-select__activated:hover gb-list,
+    .gb-select.clickable.gb-custom-select__activated button:focus + gb-list,
+    .gb-select.clickable.gb-custom-select__activated gb-list:hover {
       display: block;
     }
     :scope.gb-stylish > .gb-select:hover button,

--- a/src/tags/select/gb-select.ts
+++ b/src/tags/select/gb-select.ts
@@ -47,6 +47,7 @@ export class Select extends FluxTag<any> {
   default: boolean;
   selected: any;
   focused: boolean;
+  activated: boolean;
 
   init() {
     this.expose('select');
@@ -58,6 +59,7 @@ export class Select extends FluxTag<any> {
   setDefaults() {
     this.clearItem = { label: this.$selectable.clear || 'Unselect', clear: true };
     this.default = !this.$selectable.clear;
+    this.activated = false;
 
     if (this.default) {
       const items = this.$selectable.items;
@@ -91,8 +93,8 @@ export class Select extends FluxTag<any> {
     }
   }
 
-  focusElement(e: Event & { preventUpdate: boolean }) {
-    e.preventUpdate = true;
+  focusElement() {
+    this.activated = true;
     this.selectButton().focus();
   }
 
@@ -100,6 +102,12 @@ export class Select extends FluxTag<any> {
     this.focused = this.$selectable.hover || !this.focused;
     if (!this.focused) {
       this.selectButton().blur();
+    }
+  }
+
+  hoverActivate() {
+    if (this.$selectable.hover) {
+      this.activated = true;
     }
   }
 
@@ -123,6 +131,7 @@ export class Select extends FluxTag<any> {
   }
 
   selectCustom({ value, label }: { value: string, label: string }) {
+    this.activated = false;
     this.selectButton().blur();
     this.selectItem(label, value);
   }

--- a/test/unit/tags/select.ts
+++ b/test/unit/tags/select.ts
@@ -134,14 +134,6 @@ suite('gb-select', Select, ({
   });
 
   describe('focusElement()', () => {
-    it('should set preventUpdate to true', () => {
-      const mouseEvent: any = {};
-      tag().selectButton = (): any => ({ focus: () => null });
-
-      tag().focusElement(mouseEvent);
-
-      expect(mouseEvent.preventUpdate).to.be.true;
-    });
 
     it('should call focus on selectButton', () => {
       const focus = spy();
@@ -151,6 +143,14 @@ suite('gb-select', Select, ({
 
       expect(tag().selectButton).to.be.called;
       expect(focus).to.be.called;
+    });
+
+    it('should set activated flag to true', () => {
+      tag().selectButton = (): any => ({ focus: () => null });
+
+      tag().focusElement({});
+
+      expect(tag().activated).to.be.true;
     });
   });
 
@@ -181,6 +181,35 @@ suite('gb-select', Select, ({
 
       expect(tag().focused).to.be.false;
       expect(blur).to.be.called;
+    });
+  });
+
+  describe('hoverActivate()', () => {
+    it('should set activated flag to true if hoverable', () => {
+      tag().$selectable = <any>{ hover: true };
+
+      tag().hoverActivate();
+
+      expect(tag().activated).to.be.true;
+    });
+
+    it('should not set activated flag to true if clickable', () => {
+      tag().$selectable = <any>{ hover: false };
+      tag().activated = false;
+
+      tag().hoverActivate();
+
+      expect(tag().activated).to.be.false;
+
+    });
+
+    it('should not change the value of activated if clickable', () => {
+      tag().$selectable = <any>{ hover: false };
+      tag().activated = true;
+
+      tag().hoverActivate();
+
+      expect(tag().activated).to.be.true;
     });
   });
 
@@ -271,6 +300,17 @@ suite('gb-select', Select, ({
       expect(blur).to.be.called;
       expect(selectItem).to.be.calledWith(item.label, item.value);
     });
+
+    it('should set activated flag to false', () => {
+      const item = { value: 'hat', label: 'Hat' };
+      const selectItem = stub(tag(), 'selectItem');
+      tag().selectButton = (): any => ({ blur: () => null });
+
+      tag().selectCustom(item);
+
+      expect(tag().activated).to.be.false;
+    });
+
   });
 
   describe('clearSelection()', () => {


### PR DESCRIPTION
Remove hover selectors and hide the list using the `visibility` property
instead of the `display` property to allow a slight delay for the click event
to be registered.

http://koen.kivits.com/articles/pure-css-menu/